### PR TITLE
Gold Gym Badges can be reversible

### DIFF
--- a/trainerdex/update_fields_metadata.json
+++ b/trainerdex/update_fields_metadata.json
@@ -86,7 +86,7 @@
             "gold": 200,
             "silver": 50
         },
-        "reversable": false,
+        "reversable": true,
         "sortable": true
     },
     "gymbadges_total": {
@@ -367,9 +367,9 @@
     },
     "travel_km": {
         "levels": {
-            "bronze": 10.00,
-            "silver": 100.00,
-            "gold": 1000.00
+            "bronze": 10,
+            "silver": 100,
+            "gold": 1000
         },
         "reversable": false,
         "sortable": true


### PR DESCRIPTION
If a gym moves across cell borders, there's a possibility of gym badge state being reset upon the next spin.

See transcript from Discord:
> [Jimbobwai#4290 @ 15/11/2019](https://discordapp.com/channels/319811219093716993/608770319552872452/644997254016663553)
> > Air raid siren has moved to the war tunnels in ramsgate. Bad news if it is one of your golds. Everyone's badge has been reset to zero.
> 
> [shady#2132 @ 15/11/2019](https://discordapp.com/channels/319811219093716993/608770319552872452/645016354361049109)
> > Are you sure you've not got 2  @Jimbobwai#4290?
> > ![image](https://cdn.discordapp.com/attachments/608770319552872452/645016354361049106/Screenshot_20191115-214410_Pokmon_GO.jpg)
> 
> [Jimbobwai#4290 @ 15/11/2019](https://discordapp.com/channels/319811219093716993/608770319552872452/645016547143843888)
> > If you spin the new location, the old one disappears.
> > ![image](https://cdn.discordapp.com/attachments/608770319552872452/645017187576315917/Screenshot_20191115-214656.png)
> > Missing from the map.
> 
> [shady#2132 @ 15/11/2019](https://discordapp.com/channels/319811219093716993/608770319552872452/645017758261706752)
> > So, spin the new one and get -1 gold gym :joy:
> > It's lose-lose
> > Gym of death
> > Better update your score :wink: